### PR TITLE
Fix buffer overflow in get_challenges

### DIFF
--- a/implementation/csifish.c
+++ b/implementation/csifish.c
@@ -58,7 +58,7 @@ void csifish_keygen(unsigned char *pk, unsigned char *sk){
 }
 
 void get_challenges(const unsigned char *hash, uint32_t *challenges_index, uint8_t *challenges_sign){
-	unsigned char tmp_hash[SEED_BYTES];
+	unsigned char tmp_hash[HASH_BYTES];
 	memcpy(tmp_hash,hash,SEED_BYTES);
 
 	// slow hash function


### PR DESCRIPTION
Hello,

Your HASH macro expects a buffer which is size HASH_BYTES, but get_challenges initializes the buffer tmp_hash as size SEED_BYTES (which is half the size of HASH_BYTES). This smashes the stack. I believe this tweak should fix the problem.

Best,
Franklin